### PR TITLE
Allow command() arguments to be created via a function call.

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -7,11 +7,15 @@ const castArray = <T>(input?: T | T[]): T[] => {
   return Array.isArray(input) ? input : [input]
 }
 
-export function command(args: string[] | string, opts: loadConfig.Options = {}) {
+export type commandArgCreator = () => string[] | string;
+export function command(args: string[] | string | commandArgCreator, opts: loadConfig.Options = {}) {
   return {
     async run(ctx: {config: Config.IConfig; expectation: string}) {
       // eslint-disable-next-line require-atomic-updates
       if (!ctx.config || opts.reset) ctx.config = await loadConfig(opts).run({} as any)
+      if (typeof args === 'function') {
+        args = args()
+      }
       args = castArray(args)
       const [id, ...extra] = args
       // eslint-disable-next-line require-atomic-updates


### PR DESCRIPTION
Allow a call to command() to have arguments defined by the
result of a function.  So this is now possible:

```command(() => ["add", filename])```

Where filename can be defined in a previous `.do()` statement.

This allows tests to build command arguments dynamically rather
that at the time the test is compiled.