### PR TITLE
feat: add a `returned` value to the test context on commands

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -9,7 +9,7 @@ const castArray = <T>(input?: T | T[]): T[] => {
 
 export function command(args: string[] | string, opts: loadConfig.Options = {}) {
   return {
-    async run(ctx: {config: Interfaces.Config; expectation: string}) {
+    async run(ctx: {config: Interfaces.Config; expectation: string; returned: unknown}) {
       // eslint-disable-next-line require-atomic-updates
       if (!ctx.config || opts.reset) ctx.config = await loadConfig(opts).run({} as any)
       args = castArray(args)
@@ -17,7 +17,8 @@ export function command(args: string[] | string, opts: loadConfig.Options = {}) 
       // eslint-disable-next-line require-atomic-updates
       ctx.expectation = ctx.expectation || `runs ${args.join(' ')}`
       await ctx.config.runHook('init', {id, argv: extra})
-      await ctx.config.runCommand(id, extra)
+      // eslint-disable-next-line require-atomic-updates
+      ctx.returned = await ctx.config.runCommand(id, extra)
     },
   }
 }

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -9,7 +9,11 @@ describe('command', () => {
   .loadConfig({root})
   .stdout()
   .command(['foo:bar'])
-  .do(output => expect(output.stdout).to.equal('hello world!\n'))
+  .do(output => {
+    expect(output.stdout).to.equal('hello world!\n')
+    let {name} = output.returned as {name: string}
+    expect(name).to.equal('world')
+  })
   .it()
 
   test

--- a/test/fixtures/multi/src/commands/foo/bar.js
+++ b/test/fixtures/multi/src/commands/foo/bar.js
@@ -9,6 +9,7 @@ class CLI extends Command {
     const {flags} = await this.parse(CLI)
     const name = flags.name || 'world'
     this.log(`hello ${name}!`)
+    return {name}
   }
 }
 


### PR DESCRIPTION
While using the `command` test helper, it can be nice to check the
returned value of the executed command.

CLI commands don't usually return any specific values, but if you
consider reusing commands (via imports) to compose small commands to
build bigger commands it can be nice to be able to check the output of
a command in a test context.

I'm aware calling commands programmatically is not recommended by the
oclif documentation, however it's still a documented feature here:
https://oclif.io/docs/running_programmatically#calling-commands-directly