### PR TITLE
fix: set NODE_ENV to test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export const test = fancy
 .register('command', command)
 .register('exit', exit)
 .register('hook', hook)
+.env({NODE_ENV: 'test'})
 
 export default test
 


### PR DESCRIPTION
Set `NODE_ENV` to `test` so that oclif/core doesn't bypass the [ts-node path resolution logic](https://github.com/oclif/core/blob/v1.13.10/src/config/ts-node.ts#L44)