### PR TITLE
feat: remove deprecated module.parent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import path from 'path'
+
 import {Config} from '@oclif/core'
 import {expect, fancy, FancyTypes} from 'fancy-test'
 
@@ -6,7 +8,18 @@ import exit from './exit'
 import hook from './hook'
 import {loadConfig} from './load-config'
 
-loadConfig.root = module.parent!.filename
+function traverseFilePathUntil(filename: string, predicate: (filename: string) => boolean): string {
+  let current = filename
+  while (!predicate(current)) {
+    current = path.dirname(current)
+  }
+
+  return current
+}
+
+// Update to path.dirname(url.fileURLToPath(import.meta.url)) whenever we update tsconfig target to ES2020
+// eslint-disable-next-line unicorn/prefer-module
+loadConfig.root = traverseFilePathUntil(require.main?.path ?? module.path, p => !p.includes('node_modules'))
 
 export const test = fancy
 .register('loadConfig', loadConfig)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,3 @@
-// tslint:disable no-console
-
-import * as OS from 'os'
-
 import {expect, test} from '../src'
 
 describe('stdout', () => {
@@ -34,12 +30,19 @@ describe('stdout + stderr', () => {
   })
 })
 
+// eslint-disable-next-line unicorn/no-static-only-class
+class MockOs {
+  static platform() {
+    return 'not-a-platform'
+  }
+}
+
 for (const os of ['darwin', 'win32', 'linux']) {
   describe(os, () => {
     test
-    .stub(OS, 'platform', () => os)
+    .stub(MockOs, 'platform', () => os)
     .end('sets os', () => {
-      expect(OS.platform()).to.equal(os)
+      expect(MockOs.platform()).to.equal(os)
     })
   })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
       "./src"
     ],
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*"


### PR DESCRIPTION
Removes deprecated `module.parent` so that this library can be used on ESM plugins