### PR TITLE
feat: support identifying other root types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,12 @@ function traverseFilePathUntil(filename: string, predicate: (filename: string) =
 }
 
 // Update to path.dirname(url.fileURLToPath(import.meta.url)) whenever we update tsconfig target to ES2020
-// eslint-disable-next-line unicorn/prefer-module
-loadConfig.root = traverseFilePathUntil(require.main?.path ?? module.path, (p) => !p.includes('node_modules'))
+/* eslint-disable unicorn/prefer-module */
+loadConfig.root = traverseFilePathUntil(
+  require.main?.path ?? module.path,
+  (p) => !(p.includes('node_modules') || p.includes('.pnpm') || p.includes('.yarn')),
+)
+/* eslint-enable unicorn/prefer-module */
 
 export const test = fancy
   .register('loadConfig', loadConfig)


### PR DESCRIPTION
After some feedback on #495, I am opening this to strictly fix the issue raised in #390. This modifies the loadConfig function within index.ts to function properly when using package managers that do not create a node_modules directory.

Fixes #390