### PR TITLE
fix: restore support for single command cli test

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -20,7 +20,8 @@ export function command(
       if (!ctx.config || opts.reset) ctx.config = await loadConfig(opts).run({} as Context)
       args = castArray(args)
       const [id, ...extra] = args
-      const cmdId = toStandardizedId(id, ctx.config)
+      let cmdId = toStandardizedId(id, ctx.config)
+      if (cmdId === '.') cmdId = Symbol('SINGLE_COMMAND_CLI').toString()
       ctx.expectation ||= `runs ${args.join(' ')}`
       await ctx.config.runHook('init', {argv: extra, id: cmdId})
       ctx.returned = await ctx.config.runCommand(cmdId, extra)

--- a/test/command.test.ts
+++ b/test/command.test.ts
@@ -2,32 +2,46 @@ import {join} from 'node:path'
 
 import {expect, test} from '../src'
 
-// eslint-disable-next-line unicorn/prefer-module
-const root = join(__dirname, 'fixtures/multi')
-
 describe('command', () => {
+  // eslint-disable-next-line unicorn/prefer-module
+  const root = join(__dirname, 'fixtures/multi')
   test
-  .loadConfig({root})
-  .stdout()
-  .command(['foo:bar'])
-  .do(output => {
-    expect(output.stdout).to.equal('hello world!\n')
-    const {name} = output.returned as {name: string}
-    expect(name).to.equal('world')
-  })
-  .it()
+    .loadConfig({root})
+    .stdout()
+    .command(['foo:bar'])
+    .do((output) => {
+      expect(output.stdout).to.equal('hello world!\n')
+      const {name} = output.returned as {name: string}
+      expect(name).to.equal('world')
+    })
+    .it()
 
   test
-  .loadConfig({root})
-  .stdout()
-  .command(['foo:bar', '--name=foo'])
-  .do(output => expect(output.stdout).to.equal('hello foo!\n'))
-  .it()
+    .loadConfig({root})
+    .stdout()
+    .command(['foo:bar', '--name=foo'])
+    .do((output) => expect(output.stdout).to.equal('hello foo!\n'))
+    .it()
 
   test
-  .loadConfig({root})
-  .stdout()
-  .command(['foo bar', '--name=foo'])
-  .do(output => expect(output.stdout).to.equal('hello foo!\n'))
-  .it()
+    .loadConfig({root})
+    .stdout()
+    .command(['foo bar', '--name=foo'])
+    .do((output) => expect(output.stdout).to.equal('hello foo!\n'))
+    .it()
+})
+
+describe('single command cli', () => {
+  // eslint-disable-next-line unicorn/prefer-module
+  const root = join(__dirname, 'fixtures/single')
+  test
+    .loadConfig({root})
+    .stdout()
+    .command(['.'])
+    .do((output) => {
+      expect(output.stdout).to.equal('hello world!\n')
+      const {name} = output.returned as {name: string}
+      expect(name).to.equal('world')
+    })
+    .it()
 })

--- a/test/fixtures/single/dist/index.js
+++ b/test/fixtures/single/dist/index.js
@@ -1,0 +1,20 @@
+const {Command, Flags} = require('@oclif/core')
+
+class CLI extends Command {
+  constructor(args, opts) {
+    super(args, opts)
+  }
+
+  async run() {
+    const {flags} = await this.parse(CLI)
+    const name = flags.name || 'world'
+    this.log(`hello ${name}!`)
+    return {name}
+  }
+}
+
+CLI.flags = {
+  name: Flags.string({char: 'n', description: 'name to print'}),
+}
+
+module.exports = CLI

--- a/test/fixtures/single/package.json
+++ b/test/fixtures/single/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test",
+  "version": "0.0.0",
+  "private": true,
+  "oclif": {
+    "commands": {
+      "strategy": "single",
+      "target": "./dist/index.js"
+    },
+    "topicSeparator": " "
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "files": [
+    "/src"
+  ]
+}


### PR DESCRIPTION
Make single command CLI `.command` example work again

Fixes #531 

@W-15468995@