### PR TITLE
fix: use require.cache to resolve root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@oclif/test",
   "description": "test helpers for oclif components",
-  "version": "3.2.11",
+  "version": "3.2.12-dev.0",
   "author": "Salesforce",
   "bugs": "https://github.com/oclif/test/issues",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,14 @@ function traverseFilePathUntil(filename: string, predicate: (filename: string) =
   return current
 }
 
-// Update to path.dirname(url.fileURLToPath(import.meta.url)) whenever we migrate to ESM
 /* eslint-disable unicorn/prefer-module */
-loadConfig.root = traverseFilePathUntil(
-  require.main?.path ?? module.path,
-  (p) => !(p.includes('node_modules') || p.includes('.pnpm') || p.includes('.yarn')),
-)
+loadConfig.root =
+  process.env.OCLIF_TEST_ROOT ??
+  Object.values(require.cache).find((m) => m?.children.includes(module))?.filename ??
+  traverseFilePathUntil(
+    require.main?.path ?? module.path,
+    (p) => !(p.includes('node_modules') || p.includes('.pnpm') || p.includes('.yarn')),
+  )
 /* eslint-enable unicorn/prefer-module */
 
 // Using a named export to import fancy causes this issue: https://github.com/oclif/test/issues/516


### PR DESCRIPTION
- Use `require.cache` to find the importing file before attempting to traverse up the file system to find the root
- Allow users to set `OCLIF_TEST_ROOT` env var to an absolute path to their CLI root

Fixes #542 
@W-15643461@