### PR TITLE
feat: add ability to override `NODE_ENV`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the [V4 Migration Guide](./MIGRATION.md) if you are migrating from v3 or old
 
 - `print` - Print everything that goes to stdout and stderr.
 - `stripAnsi` - Strip ansi codes from everything that goes to stdout and stderr. Defaults to true.
+- `testNodeEnv` - Sets the `NODE_ENV` value when capturing output. Defaults to `'test'`.
 
 See the [tests](./test/capture-output.test.ts) for example usage.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ const debug = makeDebug('oclif-test')
 type CaptureOptions = {
   print?: boolean
   stripAnsi?: boolean
+  testNodeEnv?: string
 }
 
 type CaptureResult<T> = {
@@ -77,6 +78,7 @@ function splitString(str: string): string[] {
 export async function captureOutput<T>(fn: () => Promise<unknown>, opts?: CaptureOptions): Promise<CaptureResult<T>> {
   const print = opts?.print ?? false
   const stripAnsi = opts?.stripAnsi ?? true
+  const testNodeEnv = opts?.testNodeEnv || 'test'
 
   const originals = {
     NODE_ENV: process.env.NODE_ENV,
@@ -112,7 +114,7 @@ export async function captureOutput<T>(fn: () => Promise<unknown>, opts?: Captur
 
   process.stdout.write = mock('stdout')
   process.stderr.write = mock('stderr')
-  process.env.NODE_ENV = 'test'
+  process.env.NODE_ENV = testNodeEnv
 
   try {
     const result = await fn()


### PR DESCRIPTION
Hi there! This PR adds a fairly tiny change — the ability to override `NODE_ENV`.

In my use case, I set the `NODE_ENV` to `cli-test` since the CLI is often used in test environments and I'd like to avoid false positives when running CLI tests.

Thanks for this great library (the v4 changes are exactly what I've been looking for!) and thanks in advance for the review!