### PR TITLE
fix: don't spread error object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,8 +125,8 @@ export async function captureOutput<T>(fn: () => Promise<unknown>, opts?: Captur
     }
   } catch (error) {
     return {
-      ...(error instanceof Errors.CLIError && {error: {...error, message: toString(error.message)}}),
-      ...(error instanceof Error && {error}),
+      ...(error instanceof Errors.CLIError && {error: Object.assign(error, {message: toString(error.message)})}),
+      ...(error instanceof Error && {error: Object.assign(error, {message: toString(error.message)})}),
       stderr: getStderr(),
       stdout: getStdout(),
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export async function captureOutput<T>(fn: () => Promise<unknown>, opts?: Captur
   } catch (error) {
     return {
       ...(error instanceof Errors.CLIError && {error: {...error, message: toString(error.message)}}),
-      ...(error instanceof Error && {error: {...error, message: toString(error.message)}}),
+      ...(error instanceof Error && {error}),
       stderr: getStderr(),
       stdout: getStdout(),
     }


### PR DESCRIPTION
Hi there — I noticed that using spread syntax on the error object strips away a lot of helpful data that we use for our assertions so this PR helps preserve that information.

You can reproduce this by opening up a Node REPL and typing in the following:


```js
const error1 = new TypeError('one')
console.log(error1.name)
const spread = { error: { ...error1, message: 'edited' } }
console.log(spread.error.name)
```

Note how the `name` property on the error object is lost entirely.

This PR updates this logic to use `Object.assign()` instead — try the following in your Node REPL and observe that  the error's `name` information is preserved:

```js
const error2 = new TypeError('two')
console.log(error2.name)
const assigned = { error: Object.assign(error2, { message: 'edited' }) }
console.log(assigned.error.name)
```

Thanks again for all your work on this library!