### PR TITLE
build(W-23983544): migrate to TypeScript 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "prettier": "^3.9.6",
     "shx": "^0.4.0",
     "tsx": "^4.23.12",
-    "typescript": "^5.7.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import {Config, Errors, type Interfaces, run} from '@oclif/core'
 import ansis from 'ansis'
 import makeDebug from 'debug'
-import {dirname} from 'node:path'
+import path from 'node:path'
 
 const debug = makeDebug('oclif-test')
 
@@ -24,7 +24,7 @@ type MockedStderr = typeof process.stderr.write
 function traverseFilePathUntil(filename: string, predicate: (filename: string) => boolean): string {
   let current = filename
   while (!predicate(current)) {
-    current = dirname(current)
+    current = path.dirname(current)
   }
 
   return current

--- a/test/run-command.test.ts
+++ b/test/run-command.test.ts
@@ -1,12 +1,12 @@
 import {Config} from '@oclif/core'
 import {expect} from 'chai'
-import {join} from 'node:path'
+import path from 'node:path'
 
 import {runCommand} from '../src/index.js'
 
 describe('runCommand', () => {
   // eslint-disable-next-line unicorn/prefer-module
-  const root = join(__dirname, 'fixtures/multi')
+  const root = path.join(__dirname, 'fixtures/multi')
 
   it('should run a command', async () => {
     const {result, stdout} = await runCommand<{name: string}>(['foo:bar'], {root})
@@ -47,7 +47,7 @@ describe('runCommand', () => {
 
   describe('single command cli', () => {
     // eslint-disable-next-line unicorn/prefer-module
-    const root = join(__dirname, 'fixtures/single')
+    const root = path.join(__dirname, 'fixtures/single')
 
     it('should run a single command cli', async () => {
       const {result, stdout} = await runCommand<{name: string}>(['.'], {root})

--- a/test/run-hook.test.ts
+++ b/test/run-hook.test.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai'
-import {join} from 'node:path'
+import path from 'node:path'
 
 import {runHook} from '../src/index.js'
 
 // eslint-disable-next-line unicorn/prefer-module
-const root = join(__dirname, 'fixtures/multi')
+const root = path.join(__dirname, 'fixtures/multi')
 
 describe('runHook', () => {
   it('should run a hook', async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../tsconfig",
   "compilerOptions": {
-    "sourceMap": true
+    "rootDir": "../",
+    "sourceMap": true,
+    "types": ["mocha", "node"]
   },
-  "include": [
-    "./**/*",
-    "../src/**/*"
-  ]
+  "include": ["./**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,11 @@
     "noUnusedParameters": true,
     "outDir": "./lib",
     "pretty": true,
-    "rootDirs": ["./src"],
+    "rootDir": "./src",
     "strict": true,
     "target": "es2022",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["./src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4395,10 +4395,10 @@ typescript-eslint@^8.64.0, typescript-eslint@^8.67.0:
     "@typescript-eslint/typescript-estree" "8.67.0"
     "@typescript-eslint/utils" "8.67.0"
 
-typescript@^5.7.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+typescript@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 undici-types@~5.26.4:
   version "5.26.5"


### PR DESCRIPTION
### What does this PR do?
Migrates oclif/test to TypeScript v6 and updates a couple of imports to remove lint warnings.

### What issues does this PR fix or reference?
[@W-23983544@](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002ij5WBYAY/view)